### PR TITLE
JSON body-parsing errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 2.3.0 (March 16, 2018)
+
+Features:
+
+* add `cross-env` package to support all OS enviroment variables
+* change the single quote on script command to support all OS
+* add the invalid JSON error (#13)
+* fix the code example on README
+* update `ajv` dependency to a stable version
+* remove `babel-polyfill` as peerDependency (#14)
+
 ## 2.2.0 (November 20, 2017)
 
 Features:

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ exports.responses = {
 };
 exports.parameters = [{
     name: "status",
-    description: "Filter by pet status (e.g. available / not available)"
+    description: "Filter by pet status (e.g. available / not available)",
     in: "query",
     required: false,
     type: "string",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "convexpress",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Employ conventions to register express routes",
   "main": "src/index.js",
   "typings": "src/index.d.ts",
@@ -9,12 +9,12 @@
   ],
   "scripts": {
     "precommit": "yarn lint && yarn test",
-    "prettier": "prettier 'src/**/*.js' 'test/**/*.js'",
+    "prettier": "prettier \"src/**/*.js\" \"test/**/*.js\"",
     "prettify": "yarn prettier --write",
     "lint:prettier": "yarn prettier --list-different",
     "lint:eslint": "eslint src test",
     "lint": "yarn lint:prettier && yarn lint:eslint",
-    "test": "NODE_ENV=test mocha -r test/setup.js 'test/**/*.js'",
+    "test": "cross-env NODE_ENV=test mocha -r test/setup.js \"test/**/*.js\"",
     "coverage": "nyc -r html -r lcov -r text-summary npm run test",
     "publish-coverage": "codecov"
   },
@@ -32,6 +32,7 @@
     "chai-as-promised": "^7.1.1",
     "codecov": "^3.0.0",
     "create-fs-tree": "^1.0.0",
+    "cross-env": "^5.1.4",
     "eslint": "^4.11.0",
     "eslint-config-prettier": "^2.8.0",
     "husky": "^0.14.3",
@@ -47,15 +48,12 @@
   "dependencies": {
     "@types/body-parser": "^1.16.8",
     "@types/express": "^4.0.39",
-    "ajv": "^5.3.0",
+    "ajv": "^6.2.1",
     "body-parser": "^1.18.2",
     "express": "^4.16.2",
     "glob": "^7.1.2",
     "ramda": "^0.25.0",
     "swaggerize-ui": "^1.0.1",
     "type-is": "^1.6.15"
-  },
-  "peerDependencies": {
-    "babel-polyfill": "^6.20.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "convexpress",
-  "version": "2.3.0",
+  "version": "2.2.0",
   "description": "Employ conventions to register express routes",
   "main": "src/index.js",
   "typings": "src/index.d.ts",

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,15 @@ const wrap = require("./wrap");
 
 module.exports = function convexpress(options) {
     const router = Router().use(parseBody(options.bodyParserOptions));
+    router.use((err, req, res, next) => {
+        if (err instanceof SyntaxError) {
+            return res.status(415).send({
+                message: "Invalid JSON"
+            });
+        } else {
+            next();
+        }
+    });
     router.swagger = {
         swagger: "2.0",
         host: options.host,

--- a/src/index.js
+++ b/src/index.js
@@ -9,15 +9,6 @@ const wrap = require("./wrap");
 
 module.exports = function convexpress(options) {
     const router = Router().use(parseBody(options.bodyParserOptions));
-    router.use((err, req, res, next) => {
-        if (err instanceof SyntaxError) {
-            return res.status(415).send({
-                message: "Invalid JSON"
-            });
-        } else {
-            next();
-        }
-    });
     router.swagger = {
         swagger: "2.0",
         host: options.host,

--- a/src/parse-body.js
+++ b/src/parse-body.js
@@ -35,6 +35,28 @@ module.exports = function parseBody(options = {}) {
         *   out to be incorrectly encoded - e.g. not a valid json string - the
         *   middleware will take care of sending an error back to the client)
         */
-        jsonMiddleware(req, res, next);
+        jsonMiddleware(req, res, err => {
+            if (err) {
+                let text, errCode;
+                switch (err.type) {
+                    case "charset.unsupported":
+                        text = "Invalid JSON Charset";
+                        errCode = 415;
+                        break;
+                    case "encoding.unsupported":
+                        text = "Invalid JSON Content-Encoding";
+                        errCode = 415;
+                        break;
+                    case "entity.parse.failed":
+                        text = "Invalid JSON Syntax";
+                        errCode = 400;
+                        break;
+                }
+                return res.status(errCode).send({
+                    message: text
+                });
+            }
+            next();
+        });
     };
 };

--- a/src/parse-body.js
+++ b/src/parse-body.js
@@ -31,30 +31,34 @@ module.exports = function parseBody(options = {}) {
 
         /*
         *   Here the request has a non-empty, json-encoded body. We delegate its
-        *   handling to the body-parser's `json` middleware. (If the body turns
-        *   out to be incorrectly encoded - e.g. not a valid json string - the
-        *   middleware will take care of sending an error back to the client)
+        *   handling to the body-parser's `json` middleware, though we
+        *   interecept errors in order to always return a json response.
         */
         jsonMiddleware(req, res, err => {
             if (err) {
-                let text, errCode;
+                let message;
+                let statusCode;
                 switch (err.type) {
                     case "charset.unsupported":
-                        text = "Invalid JSON Charset";
-                        errCode = 415;
+                        message = "Invalid JSON Charset";
+                        statusCode = 415;
                         break;
                     case "encoding.unsupported":
-                        text = "Invalid JSON Content-Encoding";
-                        errCode = 415;
+                        message = "Invalid JSON Content-Encoding";
+                        statusCode = 415;
                         break;
                     case "entity.parse.failed":
-                        text = "Invalid JSON Syntax";
-                        errCode = 400;
+                        message = "Invalid JSON Syntax";
+                        statusCode = 400;
+                        break;
+                    default:
+                        req.log &&
+                            req.log.error(err, "Unknown error parsing body");
+                        message = "Internal server error";
+                        statusCode = 500;
                         break;
                 }
-                return res.status(errCode).send({
-                    message: text
-                });
+                return res.status(statusCode).send({ message });
             }
             next();
         });

--- a/test/unit/parse-body.js
+++ b/test/unit/parse-body.js
@@ -139,4 +139,94 @@ describe("ensureJSONBody middleware", () => {
                 .expect(400);
         });
     });
+
+    describe("415 on invalid json charset", () => {
+        it("GET", () => {
+            return request(server)
+                .get("/")
+                .set("Content-Type", "application/json; charset=ISO-8859-1")
+                .send({})
+                .expect(415)
+                .expect({
+                    message: "Invalid JSON Charset"
+                });
+        });
+        it("POST", () => {
+            return request(server)
+                .post("/")
+                .set("Content-Type", "application/json; charset=ISO-8859-1")
+                .send({})
+                .expect(415)
+                .expect({
+                    message: "Invalid JSON Charset"
+                });
+        });
+        it("PUT", () => {
+            return request(server)
+                .put("/")
+                .set("Content-Type", "application/json; charset=ISO-8859-1")
+                .send({})
+                .expect(415)
+                .expect({
+                    message: "Invalid JSON Charset"
+                });
+        });
+        it("DELETE", () => {
+            return request(server)
+                .delete("/")
+                .set("Content-Type", "application/json; charset=ISO-8859-1")
+                .send({})
+                .expect(415)
+                .expect({
+                    message: "Invalid JSON Charset"
+                });
+        });
+    });
+
+    describe("415 on invalid json content-encoding", () => {
+        it("GET", () => {
+            return request(server)
+                .get("/")
+                .set("Content-Encoding", "error")
+                .set("Content-Type", "application/json")
+                .send({})
+                .expect(415)
+                .expect({
+                    message: "Invalid JSON Content-Encoding"
+                });
+        });
+        it("POST", () => {
+            return request(server)
+                .post("/")
+                .set("Content-Encoding", "error")
+                .set("Content-Type", "application/json")
+                .send({})
+                .expect(415)
+                .expect({
+                    message: "Invalid JSON Content-Encoding"
+                });
+        });
+        it("PUT", () => {
+            return request(server)
+                .put("/")
+                .set("Content-Encoding", "error")
+                .set("Content-Type", "application/json")
+                .send({})
+                .expect(415)
+                .expect({
+                    message: "Invalid JSON Content-Encoding"
+                });
+        });
+        it("DELETE", () => {
+            return request(server)
+                .delete("/")
+                .set("Content-Encoding", "error")
+                .set("Content-Type", "application/json")
+                .send({})
+                .expect(415)
+                .expect({
+                    message: "Invalid JSON Content-Encoding"
+                });
+        });
+    });
 });

--- a/test/unit/parse-body.js
+++ b/test/unit/parse-body.js
@@ -115,28 +115,32 @@ describe("ensureJSONBody middleware", () => {
                 .get("/")
                 .set("Content-Type", "application/json")
                 .send("invalidJSON")
-                .expect(400);
+                .expect(400)
+                .expect({ message: "Invalid JSON Syntax" });
         });
         it("POST", () => {
             return request(server)
                 .post("/")
                 .set("Content-Type", "application/json")
                 .send("invalidJSON")
-                .expect(400);
+                .expect(400)
+                .expect({ message: "Invalid JSON Syntax" });
         });
         it("PUT", () => {
             return request(server)
                 .put("/")
                 .set("Content-Type", "application/json")
                 .send("invalidJSON")
-                .expect(400);
+                .expect(400)
+                .expect({ message: "Invalid JSON Syntax" });
         });
         it("DELETE", () => {
             return request(server)
                 .delete("/")
                 .set("Content-Type", "application/json")
                 .send("invalidJSON")
-                .expect(400);
+                .expect(400)
+                .expect({ message: "Invalid JSON Syntax" });
         });
     });
 
@@ -147,9 +151,7 @@ describe("ensureJSONBody middleware", () => {
                 .set("Content-Type", "application/json; charset=ISO-8859-1")
                 .send({})
                 .expect(415)
-                .expect({
-                    message: "Invalid JSON Charset"
-                });
+                .expect({ message: "Invalid JSON Charset" });
         });
         it("POST", () => {
             return request(server)
@@ -157,9 +159,7 @@ describe("ensureJSONBody middleware", () => {
                 .set("Content-Type", "application/json; charset=ISO-8859-1")
                 .send({})
                 .expect(415)
-                .expect({
-                    message: "Invalid JSON Charset"
-                });
+                .expect({ message: "Invalid JSON Charset" });
         });
         it("PUT", () => {
             return request(server)
@@ -167,9 +167,7 @@ describe("ensureJSONBody middleware", () => {
                 .set("Content-Type", "application/json; charset=ISO-8859-1")
                 .send({})
                 .expect(415)
-                .expect({
-                    message: "Invalid JSON Charset"
-                });
+                .expect({ message: "Invalid JSON Charset" });
         });
         it("DELETE", () => {
             return request(server)
@@ -177,9 +175,7 @@ describe("ensureJSONBody middleware", () => {
                 .set("Content-Type", "application/json; charset=ISO-8859-1")
                 .send({})
                 .expect(415)
-                .expect({
-                    message: "Invalid JSON Charset"
-                });
+                .expect({ message: "Invalid JSON Charset" });
         });
     });
 
@@ -191,9 +187,7 @@ describe("ensureJSONBody middleware", () => {
                 .set("Content-Type", "application/json")
                 .send({})
                 .expect(415)
-                .expect({
-                    message: "Invalid JSON Content-Encoding"
-                });
+                .expect({ message: "Invalid JSON Content-Encoding" });
         });
         it("POST", () => {
             return request(server)
@@ -202,9 +196,7 @@ describe("ensureJSONBody middleware", () => {
                 .set("Content-Type", "application/json")
                 .send({})
                 .expect(415)
-                .expect({
-                    message: "Invalid JSON Content-Encoding"
-                });
+                .expect({ message: "Invalid JSON Content-Encoding" });
         });
         it("PUT", () => {
             return request(server)
@@ -213,9 +205,7 @@ describe("ensureJSONBody middleware", () => {
                 .set("Content-Type", "application/json")
                 .send({})
                 .expect(415)
-                .expect({
-                    message: "Invalid JSON Content-Encoding"
-                });
+                .expect({ message: "Invalid JSON Content-Encoding" });
         });
         it("DELETE", () => {
             return request(server)
@@ -224,9 +214,7 @@ describe("ensureJSONBody middleware", () => {
                 .set("Content-Type", "application/json")
                 .send({})
                 .expect(415)
-                .expect({
-                    message: "Invalid JSON Content-Encoding"
-                });
+                .expect({ message: "Invalid JSON Content-Encoding" });
         });
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -70,11 +70,28 @@ ajv@^4.9.1:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-ajv@^5.2.3, ajv@^5.3.0:
+ajv@^5.2.3:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.3.0.tgz#4414ff74a50879c208ee5fdc826e32c303549eda"
   dependencies:
     co "^4.6.0"
+    fast-deep-equal "^1.0.0"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.3.0"
+
+ajv@^5.3.0:
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
+  dependencies:
+    co "^4.6.0"
+    fast-deep-equal "^1.0.0"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.3.0"
+
+ajv@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.2.1.tgz#28a6abc493a2abe0fb4c8507acaedb43fa550671"
+  dependencies:
     fast-deep-equal "^1.0.0"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
@@ -534,6 +551,13 @@ create-fs-tree@^1.0.0:
   dependencies:
     fs-extra "^3.0.1"
 
+cross-env@^5.1.4:
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.1.4.tgz#f61c14291f7cc653bb86457002ea80a04699d022"
+  dependencies:
+    cross-spawn "^5.1.0"
+    is-windows "^1.0.0"
+
 cross-spawn@^4:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
@@ -843,8 +867,8 @@ extsprintf@1.3.0, extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
 
 fast-deep-equal@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz#96256a3bc975595eb36d82e9929d060d893439ff"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
 
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
@@ -1328,6 +1352,10 @@ is-typedarray@~1.0.0:
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
+
+is-windows@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
 
 isarray@0.0.1:
   version "0.0.1"


### PR DESCRIPTION
A different method to catch the "Invalid JSON Syntax", "Invalid JSON Charset" and "Invalid JSON Content-Encoding" error. 
Also added the unit tests.